### PR TITLE
Add Excel support for data loading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 matplotlib
 reportlab
 streamlit
+openpyxl


### PR DESCRIPTION
## Summary
- add `load_and_clean_file` that handles `.csv` and `.xlsx` files
- search for either extension when loading data
- include openpyxl in requirements

## Testing
- `python -m py_compile dataAnalysis.py`

------
https://chatgpt.com/codex/tasks/task_b_6854252b61788323902f3556a097d2fe