### PR TITLE
Fix device group ranges so SM03 and SM05 appear

### DIFF
--- a/dataAnalysis.py
+++ b/dataAnalysis.py
@@ -138,8 +138,8 @@ if st.sidebar.button('Load Data'):
 
 # Device groupings
 devices    = st.session_state.get('devices', [])
-main       = [f'SM{i:02d}' for i in range(2,3)]
-crawlspace = [f'SM{i:02d}' for i in range(4,5)]
+main       = [f'SM{i:02d}' for i in range(2,4)]
+crawlspace = [f'SM{i:02d}' for i in range(4,6)]
 outdoor    = ['SM01']
 
 # Grouped checkboxes


### PR DESCRIPTION
## Summary
- include SM03 in the main group and SM05 in the crawlspace group

## Testing
- `python -m py_compile dataAnalysis.py`

------
https://chatgpt.com/codex/tasks/task_b_68542838b3308323a438356dc1ceb3d4