### PR TITLE
Rename repo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# data_Analysis_SM_2025
+
+This repository contains scripts and data for analyzing temperature and humidity measurements collected by the St. Matthias sensors in 2025.
+
+The main Streamlit application is `dataAnalysis.py`. It loads measurement exports from the `data/` directory and provides interactive visualizations and summary statistics.
+
+Run the application with:
+
+```bash
+streamlit run dataAnalysis.py
+```
+
+The repository was previously named `dataAnalysis_SM_Q1_2025` and has been updated to `data_Analysis_SM_2025`.

--- a/dataAnalysis.py
+++ b/dataAnalysis.py
@@ -83,8 +83,8 @@ def compute_correlations(df, field='Temp_F'):
     return pivot.corr(method='pearson')
 
 # --- Streamlit App ---
-st.set_page_config(page_title='St Matthias: Q1 Environmental Data Analysis', layout='wide')
-st.header('St Matthias: Q1 Environmental Data Analysis')
+st.set_page_config(page_title='St Matthias: 2025 Environmental Data Analysis', layout='wide')
+st.header('St Matthias: 2025 Environmental Data Analysis')
 
 # Sidebar logo
 #logo_path = 'Logo.PNG'


### PR DESCRIPTION
## Summary
- reference repo as `data_Analysis_SM_2025`
- clarify page title in streamlit app
- document new name

## Testing
- `python -m py_compile dataAnalysis.py`

------
https://chatgpt.com/codex/tasks/task_b_68542a356d648323a724fddc2f79cbb4