### PR TITLE
Fix logo display path

### DIFF
--- a/dataAnalysis.py
+++ b/dataAnalysis.py
@@ -87,11 +87,11 @@ st.set_page_config(page_title='St Matthias: 2025 Environmental Data Analysis', l
 st.header('St Matthias: 2025 Environmental Data Analysis')
 
 # Sidebar logo
-#logo_path = 'Logo.PNG'
-#if os.path.exists(logo_path):
-#    st.sidebar.image(logo_path, use_container_width=True)
-#else:
-#    st.sidebar.warning(f"Logo not found at {logo_path}")
+logo_path = 'Logo.png'
+if os.path.exists(logo_path):
+    st.sidebar.image(logo_path, use_container_width=True)
+else:
+    st.sidebar.warning(f"Logo not found at {logo_path}")
 
 # Settings header
 st.sidebar.title('Settings')


### PR DESCRIPTION
## Summary
- enable the sidebar logo by uncommenting the image code
- use the correct case-sensitive path `Logo.png`

## Testing
- `python -m py_compile dataAnalysis.py`


------
https://chatgpt.com/codex/tasks/task_b_68542c5e8d4c832385e2a70877d065fd