### PR TITLE
Move logo to top of page

### DIFF
--- a/dataAnalysis.py
+++ b/dataAnalysis.py
@@ -84,15 +84,15 @@ def compute_correlations(df, field='Temp_F'):
 
 # --- Streamlit App ---
 st.set_page_config(page_title='St Matthias: 2025 Environmental Data Analysis', layout='wide')
-st.header('St Matthias: 2025 Environmental Data Analysis')
-
-# Sidebar logo
+# Display logo above the title
 script_dir = os.path.dirname(os.path.abspath(__file__))
 logo_path = os.path.join(script_dir, "Logo.png")
 if os.path.exists(logo_path):
-    st.sidebar.image(logo_path, use_container_width=True)
+    st.image(logo_path, use_container_width=False)
 else:
-    st.sidebar.warning(f"Logo not found at {logo_path}")
+    st.warning(f"Logo not found at {logo_path}")
+
+st.header('St Matthias: 2025 Environmental Data Analysis')
 
 # Settings header
 st.sidebar.title('Settings')


### PR DESCRIPTION
## Summary
- display the logo above the main header instead of in the sidebar

## Testing
- `python -m py_compile dataAnalysis.py`

------
https://chatgpt.com/codex/tasks/task_b_68542e6dc8e083238fb4756a8ab48d25